### PR TITLE
Add unit tests for utilities

### DIFF
--- a/internal/encryption/helpers_test.go
+++ b/internal/encryption/helpers_test.go
@@ -1,0 +1,46 @@
+package encryption
+
+import (
+	"crypto/aes"
+	"ftcli/config"
+	"golang.org/x/crypto/chacha20"
+	"testing"
+)
+
+func TestGenerateIV(t *testing.T) {
+	iv, err := GenerateIV()
+	if err != nil {
+		t.Fatalf("GenerateIV returned error: %v", err)
+	}
+	if len(iv) != aes.BlockSize {
+		t.Errorf("expected IV length %d, got %d", aes.BlockSize, len(iv))
+	}
+}
+
+func TestGenerateSalt(t *testing.T) {
+	s, err := GenerateSalt()
+	if err != nil {
+		t.Fatalf("GenerateSalt returned error: %v", err)
+	}
+	if len(s) != 16 {
+		t.Errorf("expected salt length 16, got %d", len(s))
+	}
+}
+
+func TestGenerateNonce(t *testing.T) {
+	n, err := GenerateNonce()
+	if err != nil {
+		t.Fatalf("GenerateNonce returned error: %v", err)
+	}
+	if len(n) != chacha20.NonceSize {
+		t.Errorf("expected nonce length %d, got %d", chacha20.NonceSize, len(n))
+	}
+}
+
+func TestGenerateMasterKey(t *testing.T) {
+	salt := make([]byte, 16)
+	key := GenerateMasterKey(salt, "password")
+	if len(key) != int(config.KeyLength) {
+		t.Errorf("expected key length %d, got %d", config.KeyLength, len(key))
+	}
+}

--- a/internal/send/send_test.go
+++ b/internal/send/send_test.go
@@ -3,6 +3,7 @@ package send
 import (
 	"encoding/binary"
 	"encoding/json"
+	"ftcli/internal/shared"
 	"ftcli/models"
 	"io"
 	"net"
@@ -13,17 +14,23 @@ import (
 // Test send of header
 // This test was written by chatGPT
 func TestSendHeader(t *testing.T) {
-	c1, c2 := net.Pipe()  // c1: writer, c2: reader
+	c1, c2 := net.Pipe() // c1: writer, c2: reader
 	defer c1.Close()
 	defer c2.Close()
 
-	header := models.Header{ 
+	header := models.Header{
 		FileName: "foo.bar",
 		CheckSum: "11586d2eb43b73e539caa3d158c883336c0e2c904b309c0c5ffe2c9b83d562a1",
 	}
 
+	hdrJSON, err := shared.HeaderToJsonB(header)
+	if err != nil {
+		t.Fatalf("failed to marshal header: %v", err)
+	}
+	hdrLen := shared.GetHeaderLength(hdrJSON)
+
 	go func() {
-		err := sendHeader(c1, header)
+		err := sendHeader(c1, hdrJSON, hdrLen)
 		if err != nil {
 			t.Errorf("sendHeader failed: %v", err)
 		}
@@ -52,4 +59,3 @@ func TestSendHeader(t *testing.T) {
 		t.Errorf("mismatch:\nexpected: %+v\ngot: %+v", header, received)
 	}
 }
-

--- a/internal/shared/file_operations_test.go
+++ b/internal/shared/file_operations_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Test CopyAndHash's copy from reader to writer and hash generation
-func TestCopyAndHash(t *testing.T){
+func TestCopyAndHash(t *testing.T) {
 
 	// create reader and writer
 	fileText := "This is a test\n"
@@ -24,12 +24,12 @@ func TestCopyAndHash(t *testing.T){
 		t.Fatal(err)
 	}
 	fileChkSum := fmt.Sprintf("%x", hash.Sum(nil))
-	
+
 	// reset to the top of the reader
 	reader.Seek(0, io.SeekStart)
 
 	// copy from reader to writer and get hash of transfered contents
-	retHashStr, _ , err := CopyAndHash(&writer, reader)
+	retHashStr, _, err := CopyAndHash(&writer, reader)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,13 +37,13 @@ func TestCopyAndHash(t *testing.T){
 	// compare the values
 	if retHashStr != fileChkSum {
 		t.Errorf("Hashes don't match.\nExpected Hash: %v\nReturned Hash: %v", fileChkSum, retHashStr)
-	}else{
+	} else {
 		t.Logf("Hashes match.\nExpected Hash: %v\nReturned Hash: %v", fileChkSum, retHashStr)
 	}
 }
 
 // Test FileChecksum ability to return real hash
-func TestFileChecksum(t *testing.T){
+func TestFileChecksum(t *testing.T) {
 
 	// create temp file in tempdir
 	file, err := os.CreateTemp(os.TempDir(), "testfile.*")
@@ -61,21 +61,21 @@ func TestFileChecksum(t *testing.T){
 
 	// write some text to the file
 	fileText := "This is a test\n"
-	byteText := []byte(fileText) 
+	byteText := []byte(fileText)
 	file.Write(byteText)
-	if err != nil{
+	if err != nil {
 		t.Fatal(err)
 	}
-	
+
 	// move cursor to the top of the file
-	file.Seek(0,io.SeekStart)
+	file.Seek(0, io.SeekStart)
 
 	// get the hash for the file
 	hash := sha256.New()
-	if _ , err = io.Copy(hash, file); err != nil {
+	if _, err = io.Copy(hash, file); err != nil {
 		t.Fatal(err)
 	}
-	sum := fmt.Sprintf("%x",hash.Sum(nil))
+	sum := fmt.Sprintf("%x", hash.Sum(nil))
 
 	// use the function to get the checksum of the file
 	chkSum, err := FileChecksumSHA265(file)
@@ -85,7 +85,7 @@ func TestFileChecksum(t *testing.T){
 
 	if chkSum != sum {
 		t.Errorf("Hashes don't match.\nExpected Hash: %v\nReturned Hash: %v", sum, chkSum)
-	}else{
+	} else {
 		t.Logf("Hashes match.\nExpected Hash: %v\nReturned Hash: %v", sum, chkSum)
 	}
 }

--- a/internal/shared/header_test.go
+++ b/internal/shared/header_test.go
@@ -1,0 +1,34 @@
+package shared
+
+import (
+	"encoding/binary"
+	"ftcli/models"
+	"reflect"
+	"testing"
+)
+
+func TestHeaderEncodingAndDecoding(t *testing.T) {
+	hdr := models.Header{FileName: "file.txt", CheckSum: "abc", Nonce: []byte{1, 2, 3}, Salt: []byte{4, 5}, IV: []byte{6}}
+	jsonBytes, err := HeaderToJsonB(hdr)
+	if err != nil {
+		t.Fatalf("HeaderToJsonB failed: %v", err)
+	}
+	decoded, err := JsonBToHeader(jsonBytes)
+	if err != nil {
+		t.Fatalf("JsonBToHeader failed: %v", err)
+	}
+	if !reflect.DeepEqual(hdr, *decoded) {
+		t.Errorf("header mismatch after encode/decode\nexpected:%+v\n got:%+v", hdr, *decoded)
+	}
+}
+
+func TestGetHeaderLength(t *testing.T) {
+	data := []byte{1, 2, 3, 4, 5}
+	lenBytes := GetHeaderLength(data)
+	if len(lenBytes) != 4 {
+		t.Fatalf("expected 4 bytes, got %d", len(lenBytes))
+	}
+	if l := binary.BigEndian.Uint32(lenBytes); l != uint32(len(data)) {
+		t.Errorf("expected length %d, got %d", len(data), l)
+	}
+}

--- a/internal/shared/suggest_test.go
+++ b/internal/shared/suggest_test.go
@@ -1,0 +1,20 @@
+package shared
+
+import "testing"
+
+func TestSuggestNewFileName(t *testing.T) {
+	tests := []struct {
+		input string
+		ctr   int
+		want  string
+	}{
+		{"test.txt", 1, "test.1.txt"},
+		{"file.tar.gz", 3, "file.tar.3.gz"},
+	}
+	for _, tt := range tests {
+		got := SuggestNewFileName(tt.input, tt.ctr)
+		if got != tt.want {
+			t.Errorf("SuggestNewFileName(%q,%d) = %q, want %q", tt.input, tt.ctr, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- expand sendHeader test to use current function signature
- ensure newline and cleanup in file_operations_test
- add new tests for header helpers
- add tests for filename suggestions
- add tests for encryption helper functions

## Testing
- `go test ./...` *(fails: downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6853675c645c83288cc395fd85509a07